### PR TITLE
Add login instructions for Anki

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.12-slim
+
+ENV ANKICONNECT_PORT=8765
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+       anki xvfb git \
+    && rm -rf /var/lib/apt/lists/*
+
+# install AnkiConnect addon
+RUN mkdir -p /opt/anki-connect \
+    && git clone --depth 1 https://github.com/FooSoft/anki-connect /opt/anki-connect
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY anki_bot.py /app/anki_bot.py
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE ${ANKICONNECT_PORT}
+VOLUME ["/root/.local/share/Anki2"]
+WORKDIR /app
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Add Anki Telegram Bot
+
+This project builds a Docker image containing Anki, the AnkiConnect add-on and a Telegram bot.
+
+## First-time setup
+
+The container starts Anki headlessly under Xvfb and exposes the AnkiConnect port. To synchronise with your AnkiWeb account you must sign in once using the standard Anki interface. The easiest method is:
+
+1. Build the image locally:
+
+```bash
+docker build -t add-anki-telegram .
+```
+
+2. Run the container interactively with access to your host display:
+
+```bash
+docker run --rm -e DISPLAY=your_display -v anki_data:/root/.local/share/Anki2 add-anki-telegram bash
+```
+
+3. Inside the container launch `anki` and log in with your AnkiWeb ID and password. These credentials are stored in the mounted profile directory (`anki_data` volume) so subsequent runs will automatically sync.
+
+After logging in you can start the service normally using `docker-compose up -d`.
+
+## Environment variables
+
+- `TELEGRAM_TOKEN` – Token for your Telegram bot
+- `OPENAI_API_KEY` – API key for OpenAI
+- `ANKICONNECT_PORT` – Port exposed by AnkiConnect (default `8765`)
+
+## Build and run
+
+```bash
+docker-compose up --build
+```
+
+The profile data is persisted in the `anki_data` volume.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  anki_bot:
+    build: .
+    ports:
+      - "${ANKICONNECT_PORT:-8765}:${ANKICONNECT_PORT:-8765}"
+    environment:
+      TELEGRAM_TOKEN: ${TELEGRAM_TOKEN}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      ANKICONNECT_PORT: ${ANKICONNECT_PORT:-8765}
+    volumes:
+      - anki_data:/root/.local/share/Anki2
+    restart: unless-stopped
+
+volumes:
+  anki_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+PROFILE_DIR=${ANKI_PROFILE_DIR:-$HOME/.local/share/Anki2}
+ADDON_DIR="$PROFILE_DIR/addons21/2055492159"
+
+mkdir -p "$PROFILE_DIR/addons21"
+
+# copy AnkiConnect addon if not present
+if [ ! -d "$ADDON_DIR" ]; then
+  cp -r /opt/anki-connect "$ADDON_DIR"
+fi
+
+# update port in config if needed
+CONFIG_FILE="$ADDON_DIR/config.json"
+if [ -n "$ANKICONNECT_PORT" ]; then
+  if [ -f "$CONFIG_FILE" ]; then
+    sed -i "s/\"webBindPort\": [0-9]\+/\"webBindPort\": $ANKICONNECT_PORT/" "$CONFIG_FILE"
+  fi
+fi
+
+xvfb-run --server-args="-screen 0 1024x768x24" anki --no-sound &
+ANKI_PID=$!
+
+python /app/anki_bot.py &
+BOT_PID=$!
+
+wait $BOT_PID
+kill $ANKI_PID

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-telegram-bot==20.7
+openai>=1.0
+python-dotenv
+requests


### PR DESCRIPTION
## Summary
- document how to sign in to AnkiWeb when using the container
- clarify that you need to build the Docker image first

## Testing
- `python -m py_compile anki_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6884cf6f0a048321a4d410eeb8bb3cf6